### PR TITLE
Add 301 to Acceptable Download Status Codes

### DIFF
--- a/htpclient/download.py
+++ b/htpclient/download.py
@@ -20,8 +20,8 @@ class Download:
             # Check header
             if not no_header:
                 head = session.head(url)
-                # not sure if we only should allow 200/302, but then it's present for sure
-                if head.status_code != 200 and head.status_code != 302:
+                # not sure if we only should allow 200/301/302, but then it's present for sure
+                if head.status_code not in [200, 301, 302]:
                     logging.error("File download header reported wrong status code: " + str(head.status_code))
                     return False
 


### PR DESCRIPTION
When Hashtopolis is placed behind a proxy that redirects HTTP requests to their HTTPS equivalent by means of a 301 (Permanent Redirect) status code, Hashtopolis refuses to download certain files as the only acceptable status codes are currently 200 (OK) and 302 (Temporary Redirect).

This pull request modifies the conditional that verifies the status code to use an array of acceptable status codes, and adds the 301 (Permanent Redirect) status code to the array.