### PR TITLE
Add hashcat v6.2.2 to the Hashcat Compability list

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ In order to use the multicast distribution for files, please make sure that the 
 
 The list contains all Hashcat versions with which the client was tested and is able to work with (other versions might work):
 
+* 6.2.2
 * 6.1.1
 * 6.1.0
 * 6.0.0


### PR DESCRIPTION
This version seems to work fine?