### PR TITLE
Bug fix: invalid name of devices

### DIFF
--- a/htpclient/initialize.py
+++ b/htpclient/initialize.py
@@ -98,8 +98,8 @@ class Initialize:
             for line in output:
                 if not line:
                     continue
-                line = line.split(":")
-                devices.append(line[2].strip())
+                line = ' '.join(line.split(' ')[1:]).split(':')
+                devices.append(line[1].strip())
 
         elif Initialize.get_os() == 1:  # windows
             output = subprocess.check_output("wmic cpu get name", shell=True)


### PR DESCRIPTION
On some platforms PCI devices can become nested, this causes there to be one more column in the device name.

Example:
```
72:00:0000.0 VGA compatible controller: NVIDIA Corporation TU104 [GeForce RTX 2080] (rev a1)

# versus:

72:00.0 VGA compatible controller: NVIDIA Corporation TU104 [GeForce RTX 2080] (rev a1)
```

This will mark the device as a `VGA compatible controller` and not as `NVIDIA Corporation TU104 [GeForce RTX 2080] (rev a1)`

This pull requests fixes that.

The following images show the bug in action and the fix. The first agent is added using the old agent, the second is added after the fix.

![image](https://user-images.githubusercontent.com/4386076/170064745-e3b46565-34af-48b7-b1d9-f1f9939b8f7a.png)
