### PR TITLE
VSCode devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,42 @@
+FROM nvidia/cuda:11.4.3-devel-ubuntu20.04
+
+# Avoid warnings by switching to noninteractive
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN groupadd vscode && useradd -rm -d /app -s /bin/bash -g vscode -u 1001 vscode
+
+RUN apt-get update \
+    && apt-get install python3 python3-pip -y \
+    && apt-get install git -y 
+
+# Install Intel OpenCL Runtime
+RUN cd /tmp \
+    && apt install wget lsb-core libnuma-dev pciutils -y \
+    && wget http://registrationcenter-download.intel.com/akdlm/irc_nas/vcp/15532/l_opencl_p_18.1.0.015.tgz \
+    && tar xzvf l_opencl_p_18.1.0.015.tgz \
+    && cd l_opencl_p_18.1.0.015 \
+    && echo "ACCEPT_EULA=accept" > silent.cfg \
+    && echo "PSET_INSTALL_DIR=/opt/intel" >> silent.cfg \
+    && echo "CONTINUE_WITH_OPTIONAL_ERROR=yes" >> silent.cfg \
+    && echo "CONTINUE_WITH_INSTALLDIR_OVERWRITE=yes" >> silent.cfg \
+    && echo "COMPONENTS=DEFAULTS" >> silent.cfg \
+    && echo "PSET_MODE=install" >> silent.cfg \
+    && ./install.sh -s silent.cfg
+
+# Clean
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/l_opencl_p_18.1.0.015*
+
+# Switch back to dialog for any ad-hoc use of apt-get
+ENV DEBIAN_FRONTEND=dialog
+
+# Configuring app / python requirements
+WORKDIR /app
+USER vscode
+COPY requirements.txt /app/src/
+RUN /usr/bin/pip3 install -r src/requirements.txt
+
+# Preventing container from exiting
+CMD tail -f /dev/null

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,13 @@
 FROM nvidia/cuda:11.4.3-devel-ubuntu20.04
 
+ARG DEV_CONTAINER_USER_CMD
+
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
+
+# Check for and run optional user-supplied command to enable (advanced) customizations of the dev container
+RUN [ -n "${DEV_CONTAINER_USER_CMD}" ] \
+    && echo "${DEV_CONTAINER_USER_CMD}" | sh
 
 RUN groupadd vscode && useradd -rm -d /app -s /bin/bash -g vscode -u 1001 vscode
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+	"name": "Hashtopolis-agent Devcontainer",
+	"dockerComposeFile": "docker-compose.yml",
+	"service": "hashtopolis-agent",
+
+	"workspaceFolder": "/app/src",
+
+	"extensions": [
+		"ms-python.python"
+	],
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3"
+services:
+  hashtopolis-agent:
+    container_name: hashtopolis_agent
+    build:
+      context: ..
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      # This is where VS Code should expect to find your project's source code
+      # and the value of "workspaceFolder" in .devcontainer/devcontainer.json
+      - ..:/app/src
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - capabilities: [gpu]
+
+networks:
+  default:
+      external:
+        name: hashtopolis_dev

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ..
       dockerfile: .devcontainer/Dockerfile
+      args:
+        - DEV_CONTAINER_USER_CMD
     volumes:
       # This is where VS Code should expect to find your project's source code
       # and the value of "workspaceFolder" in .devcontainer/devcontainer.json

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 .idea
 venv
 lock.pid
+.env

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": ".",
+            "args": ["--url", "http://hashtopolis/api/server.php", "--debug", "--voucher", "devvoucher"],
+            "console": "integratedTerminal",
+            "justMyCode": true
+        }
+    ]
+}


### PR DESCRIPTION
This pull request fixes https://github.com/hashtopolis/server/issues/773

To use it, make sure you have a good working nvidia driver installed and or have an Intel CPU capable of running OpenCL code. 

Make sure Docker is setup using:
https://github.com/hashtopolis/server/wiki/Development-environment

In vscode select 'Open Folder in Container' either by (CTRL + SHIFT + P, type: Open Folder in Container) or press the green extension button in the left bottom and select the option, now select the folder where hashtopolis-agent-python is locaed

Press F5 in VSCode to start the agent. It should automatically connect to the hashtopolis-server devcontainer and register itself.