### PR TITLE
Minor devcontainer improvements

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:11.4.3-devel-ubuntu20.04
+FROM ubuntu:20.04
 
 ARG DEV_CONTAINER_USER_CMD
 
@@ -6,8 +6,7 @@ ARG DEV_CONTAINER_USER_CMD
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Check for and run optional user-supplied command to enable (advanced) customizations of the dev container
-RUN [ -n "${DEV_CONTAINER_USER_CMD}" ] \
-    && echo "${DEV_CONTAINER_USER_CMD}" | sh
+RUN if [ -n "${DEV_CONTAINER_USER_CMD}" ]; then echo "${DEV_CONTAINER_USER_CMD}" | sh ; fi
 
 RUN groupadd vscode && useradd -rm -d /app -s /bin/bash -g vscode -u 1001 vscode
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,11 +11,6 @@ services:
       # This is where VS Code should expect to find your project's source code
       # and the value of "workspaceFolder" in .devcontainer/devcontainer.json
       - ..:/app/src
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - capabilities: [gpu]
 
 networks:
   default:


### PR DESCRIPTION
This now changes the default container file to ubuntu container. This is because the default should now run on almost any intel based platform. This is far more leaner, if someone wants nvidia support in the dev container; instructions can be found on the wiki.

This also fixes an issue which was already solved in the server dev container. This is related to the DEV_CONTAINER_USER_CMD failing when not being set.