### PR TITLE
Made save paths for data configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,22 +31,31 @@ Please note:
 ### Command Line Arguments
 
 ```
-usage: python3 hashtopolis.zip [-h] [--de-register] [--version]
-                               [--number-only] [--disable-update] [--debug]
-                               [--voucher VOUCHER] [--url URL]
+usage: python3 hashtopolis.zip [-h] [--de-register] [--version] [--number-only] [--disable-update] [--debug] [--voucher VOUCHER] [--url URL] [--cert CERT] [--files-path FILES_PATH]
+                               [--crackers-path CRACKERS_PATH] [--hashlists-path HASHLISTS_PATH] [--preprocessors-path PREPROCESSORS_PATH] [--zaps-path ZAPS_PATH]
 
-Hashtopolis Client v0.6.0
+Hashtopolis Client v0.6.1
 
 optional arguments:
-  -h, --help         show this help message and exit
-  --de-register      client should automatically de-register from server now
-  --version          show version information
-  --number-only      when using --version show only the number
-  --disable-update   disable retrieving auto-updates of the client from the
-                     server
-  --debug, -d        enforce debugging output
-  --voucher VOUCHER  voucher to use to automatically register
-  --url URL          URL to Hashtopolis client API
+  -h, --help            show this help message and exit
+  --de-register         client should automatically de-register from server now
+  --version             show version information
+  --number-only         when using --version show only the number
+  --disable-update      disable retrieving auto-updates of the client from the server
+  --debug, -d           enforce debugging output
+  --voucher VOUCHER     voucher to use to automatically register
+  --url URL             URL to Hashtopolis client API
+  --cert CERT           Client TLS cert bundle for Hashtopolis client API
+  --files-path FILES_PATH
+                        Use given folder path as files location
+  --crackers-path CRACKERS_PATH
+                        Use given folder path as crackers location
+  --hashlists-path HASHLISTS_PATH
+                        Use given folder path as hashlists location
+  --preprocessors-path PREPROCESSORS_PATH
+                        Use given folder path as preprocessors location
+  --zaps-path ZAPS_PATH
+                        Use given folder path as zaps location
 ```
 
 ### Config
@@ -81,6 +90,11 @@ When you run the client for the first time it will ask automatically for all the
 | auth-user             | string  |         | HTTP Basic Auth user                                                       |
 | auth-password         | string  |         | HTTP Basic Auth password                                                   |
 | outfile-history       | boolean | false   | Keep old hashcat outfiles with founds and not getting them overwritten     |
+| files-path            | string  |         | Use given folder path as files location                                    |
+| crackers-path         | string  |         | Use given folder path as crackers location                                 |
+| hashlists-path        | string  |         | Use given folder path as hashlists location                                |
+| preprocessors-path    | string  |         | Use given folder path as preprocessors location                            |
+| zaps-path             | string  |         | Use given folder path as zaps location                                     |
 
 ### Debug example
 
@@ -110,6 +124,7 @@ In order to use the multicast distribution for files, please make sure that the 
 
 The list contains all Hashcat versions with which the client was tested and is able to work with (other versions might work):
 
+* 6.2.5
 * 6.2.4
 * 6.2.3
 * 6.2.2

--- a/__main__.py
+++ b/__main__.py
@@ -2,6 +2,7 @@ import glob
 import shutil
 import signal
 import sys
+import os
 import time
 from time import sleep
 
@@ -47,13 +48,13 @@ def run_health_check():
     logging.info("Starting check ID " + str(check_id))
 
     # write hashes to file
-    hash_file = open("hashlists/health_check.txt", "w")
+    hash_file = open(CONFIG.get_value('hashlists-path') + "/health_check.txt", "w")
     hash_file.write("\n".join(ans['hashes']))
     hash_file.close()
 
     # delete old file if necessary
-    if os.path.exists("hashlists/health_check.out"):
-        os.unlink("hashlists/health_check.out")
+    if os.path.exists(CONFIG.get_value('hashlists-path') + "/health_check.out"):
+        os.unlink(CONFIG.get_value('hashlists-path') + "/health_check.out")
 
     # run task
     cracker = HashcatCracker(ans['crackerBinaryId'], binaryDownload)
@@ -62,8 +63,8 @@ def run_health_check():
     end = int(time.time())
 
     # read results
-    if os.path.exists("hashlists/health_check.out"):
-        founds = file_get_contents("hashlists/health_check.out").replace("\r\n", "\n").split("\n")
+    if os.path.exists(CONFIG.get_value('hashlists-path') + "/health_check.out"):
+        founds = file_get_contents(CONFIG.get_value('hashlists-path') + "/health_check.out").replace("\r\n", "\n").split("\n")
     else:
         founds = []
     if len(states) > 0:
@@ -118,15 +119,37 @@ def init_logging(args):
 def init(args):
     global CONFIG, binaryDownload
 
+    if len(CONFIG.get_value('files-path')) == 0:
+        CONFIG.set_value(os.path.abspath('files'))
+    if len(CONFIG.get_value('crackers-path')) == 0:
+        CONFIG.set_value(os.path.abspath('crackers'))
+    if len(CONFIG.get_value('hashlists-path')) == 0:
+        CONFIG.set_value(os.path.abspath('hashlists'))
+    if len(CONFIG.get_value('zaps-path')) == 0:
+        CONFIG.set_value(os.path.abspath('.'))
+    if len(CONFIG.get_value('preprocessors-path')) == 0:
+        CONFIG.set_value(os.path.abspath('preprocessors'))
+
+    if args.files_path and len(args.files_path):
+        CONFIG.set_value('files-path', os.path.abspath(args.files_path))
+    if args.crackers_path and len(args.crackers_path):
+        CONFIG.set_value('crackers-path', os.path.abspath(args.crackers_path))
+    if args.hashlists_path and len(args.hashlists_path):
+        CONFIG.set_value('hashlists-path', os.path.abspath(args.hashlists_path))
+    if args.zaps_path and len(args.zaps_path):
+        CONFIG.set_value('zaps-path', os.path.abspath(args.zaps_path))
+    if args.preprocessors_path and len(args.preprocessors_path):
+        CONFIG.set_value('preprocessors-path', os.path.abspath(args.preprocessors_path))
+
     logging.info("Starting client '" + Initialize.get_version() + "'...")
 
     # check if there are running hashcat.pid files around (as we assume that nothing is running anymore if the client gets newly started)
-    if os.path.exists("crackers"):
-        for root, dirs, files in os.walk("crackers"):
+    if os.path.exists(CONFIG.get_value('crackers-path')):
+        for root, dirs, files in os.walk(CONFIG.get_value('crackers-path')):
             for folder in dirs:
-                if folder.isdigit() and os.path.exists("crackers/" + folder + "/hashtopolis.pid"):
-                    logging.info("Cleaning hashcat PID file from crackers/" + folder)
-                    os.unlink("crackers/" + folder + "/hashtopolis.pid")
+                if folder.isdigit() and os.path.exists(CONFIG.get_value('crackers-path') + "/" + folder + "/hashtopolis.pid"):
+                    logging.info("Cleaning hashcat PID file from " + CONFIG.get_value('crackers-path') + "/" + folder)
+                    os.unlink(CONFIG.get_value('crackers-path') + "/" + folder + "/hashtopolis.pid")
 
     session = Session(requests.Session()).s
     session.headers.update({'User-Agent': Initialize.get_version()})
@@ -281,7 +304,7 @@ def de_register():
     else:
         logging.info("Successfully de-registered!")
         # cleanup
-        dirs = ['crackers', 'prince', 'hashlists', 'files']
+        dirs = [CONFIG.get_value('crackers-path'), CONFIG.get_value('preprocessors-path'), CONFIG.get_value('hashlists-path'), CONFIG.get_value('files-path')]
         files = ['config.json', '7zr.exe', '7zr']
         for file in files:
             if os.path.exists(file):
@@ -289,7 +312,7 @@ def de_register():
         for directory in dirs:
             if os.path.exists(directory):
                 shutil.rmtree(directory)
-        r = glob.glob('hashlist_*')
+        r = glob.glob(CONFIG.get_value('zaps-path') + '/hashlist_*')
         for i in r:
             shutil.rmtree(i)
         logging.info("Cleanup finished!")
@@ -305,6 +328,11 @@ if __name__ == "__main__":
     parser.add_argument('--voucher', type=str, required=False, help='voucher to use to automatically register')
     parser.add_argument('--url', type=str, required=False, help='URL to Hashtopolis client API')
     parser.add_argument('--cert', type=str, required=False, help='Client TLS cert bundle for Hashtopolis client API')
+    parser.add_argument('--files-path', type=str, required=False, help='Use given folder path as files location')
+    parser.add_argument('--crackers-path', type=str, required=False, help='Use given folder path as crackers location')
+    parser.add_argument('--hashlists-path', type=str, required=False, help='Use given folder path as hashlists location')
+    parser.add_argument('--preprocessors-path', type=str, required=False, help='Use given folder path as preprocessors location')
+    parser.add_argument('--zaps-path', type=str, required=False, help='Use given folder path as zaps location')
     args = parser.parse_args()
 
     if args.version:

--- a/__main__.py
+++ b/__main__.py
@@ -120,15 +120,15 @@ def init(args):
     global CONFIG, binaryDownload
 
     if len(CONFIG.get_value('files-path')) == 0:
-        CONFIG.set_value(os.path.abspath('files'))
+        CONFIG.set_value('files-path', os.path.abspath('files'))
     if len(CONFIG.get_value('crackers-path')) == 0:
-        CONFIG.set_value(os.path.abspath('crackers'))
+        CONFIG.set_value('crackers-path', os.path.abspath('crackers'))
     if len(CONFIG.get_value('hashlists-path')) == 0:
-        CONFIG.set_value(os.path.abspath('hashlists'))
+        CONFIG.set_value('hashlists-path', os.path.abspath('hashlists'))
     if len(CONFIG.get_value('zaps-path')) == 0:
-        CONFIG.set_value(os.path.abspath('.'))
+        CONFIG.set_value('zaps-path', os.path.abspath('.'))
     if len(CONFIG.get_value('preprocessors-path')) == 0:
-        CONFIG.set_value(os.path.abspath('preprocessors'))
+        CONFIG.set_value('preprocessors-path', os.path.abspath('preprocessors'))
 
     if args.files_path and len(args.files_path):
         CONFIG.set_value('files-path', os.path.abspath(args.files_path))

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## v0.6.1 -> v0.x.x
 
+### Enhancements
+
+* Paths for files, crackers, hashlists, zaps and preprocessors can be set via command line args or config.
+
 ## v0.6.0 -> v0.6.1
 
 ### Features

--- a/htpclient/binarydownload.py
+++ b/htpclient/binarydownload.py
@@ -135,7 +135,7 @@ class BinaryDownload:
     
     def check_preprocessor(self, task):
         logging.debug("Checking if requested preprocessor is present...")
-        path = "preprocessor/" + str(task.get_task()['preprocessor']) + "/"
+        path = self.config.get_value('preprocessors-path') + "/" + str(task.get_task()['preprocessor']) + "/"
         query = copy_and_set_token(dict_downloadBinary, self.config.get_value('token'))
         query['type'] = 'preprocessor'
         query['preprocessorId'] = task.get_task()['preprocessor']
@@ -173,7 +173,7 @@ class BinaryDownload:
         return True
 
     def check_version(self, cracker_id):
-        path = "crackers/" + str(cracker_id) + "/"
+        path = self.config.get_value('crackers-path') + "/" + str(cracker_id) + "/"
         query = copy_and_set_token(dict_downloadBinary, self.config.get_value('token'))
         query['type'] = 'cracker'
         query['binaryVersionId'] = cracker_id
@@ -191,19 +191,19 @@ class BinaryDownload:
             self.last_version = ans
             if not os.path.isdir(path):
                 # we need to download the 7zip
-                if not Download.download(ans['url'], "crackers/" + str(cracker_id) + ".7z"):
+                if not Download.download(ans['url'], self.config.get_value('crackers-path') + "/" + str(cracker_id) + ".7z"):
                     logging.error("Download of cracker binary failed!")
                     sleep(5)
                     return False
                 if Initialize.get_os() == 1:
-                    os.system("7zr" + Initialize.get_os_extension() + " x -ocrackers/temp crackers/" + str(cracker_id) + ".7z")
+                    os.system("7zr" + Initialize.get_os_extension() + " x -o'" + self.config.get_value('crackers-path') + "/temp' '" + self.config.get_value('crackers-path') + "/" + str(cracker_id) + ".7z'")
                 else:
-                    os.system("./7zr" + Initialize.get_os_extension() + " x -ocrackers/temp crackers/" + str(cracker_id) + ".7z")
-                os.unlink("crackers/" + str(cracker_id) + ".7z")
-                for name in os.listdir("crackers/temp"):
-                    if os.path.isdir("crackers/temp/" + name):
-                        os.rename("crackers/temp/" + name, "crackers/" + str(cracker_id))
+                    os.system("./7zr" + Initialize.get_os_extension() + " x -o'" + self.config.get_value('crackers-path') + "/temp' '" + self.config.get_value('crackers-path') + "/" + str(cracker_id) + ".7z'")
+                os.unlink(self.config.get_value('crackers-path') + "/" + str(cracker_id) + ".7z")
+                for name in os.listdir(self.config.get_value('crackers-path') + "/temp"):
+                    if os.path.isdir(self.config.get_value('crackers-path') + "/temp/" + name):
+                        os.rename(self.config.get_value('crackers-path') + "/temp/" + name, self.config.get_value('crackers-path') + "/" + str(cracker_id))
                     else:
-                        os.rename("crackers/temp", "crackers/" + str(cracker_id))
+                        os.rename(self.config.get_value('crackers-path') + "/temp", self.config.get_value('crackers-path') + "/" + str(cracker_id))
                         break
         return True

--- a/htpclient/files.py
+++ b/htpclient/files.py
@@ -38,19 +38,19 @@ class Files:
             for filename in files:
                 if filename.find("/") != -1 or filename.find("\\") != -1:
                     continue  # ignore invalid file names
-                elif os.path.dirname("files/" + filename) != "files":
+                elif os.path.dirname(self.config.get_value('files-path') + "/" + filename) != "files":
                     continue  # ignore any case in which we would leave the files folder
-                elif os.path.exists("files/" + filename):
+                elif os.path.exists(self.config.get_value('files-path') + "/" + filename):
                     logging.info("Delete file '" + filename + "' as requested by server...")
-                    if os.path.splitext("files/" + filename)[1] == '.7z':
-                        if os.path.exists("files/" + filename.replace(".7z", ".txt")):
+                    if os.path.splitext(self.config.get_value('files-path') + "/" + filename)[1] == '.7z':
+                        if os.path.exists(self.config.get_value('files-path') + "/" + filename.replace(".7z", ".txt")):
                             logging.info("Also delete assumed wordlist from archive of same file...")
-                            os.unlink("files/" + filename.replace(".7z", ".txt"))
-                    os.unlink("files/" + filename)
+                            os.unlink(self.config.get_value('files-path') + "/" + filename.replace(".7z", ".txt"))
+                    os.unlink(self.config.get_value('files-path') + "/" + filename)
 
     def check_files(self, files, task_id):
         for file in files:
-            file_localpath = "files/" + file
+            file_localpath = self.config.get_value('files-path') + "/" + file
             query = copy_and_set_token(dict_getFile, self.config.get_value('token'))
             query['taskId'] = task_id
             query['file'] = file
@@ -85,10 +85,10 @@ class Files:
                     logging.error("file size mismatch on file: %s" % file)
                     sleep(5)
                     return False
-                if os.path.splitext("files/" + file)[1] == '.7z' and not os.path.isfile("files/" + file.replace(".7z", ".txt")):
+                if os.path.splitext(self.config.get_value('files-path') + "/" + file)[1] == '.7z' and not os.path.isfile(self.config.get_value('files-path') + "/" + file.replace(".7z", ".txt")):
                     # extract if needed
                     if Initialize.get_os() != 1:
-                        os.system("./7zr" + Initialize.get_os_extension() + " x -aoa -ofiles/ -y files/" + file)
+                        os.system("./7zr" + Initialize.get_os_extension() + " x -aoa -o'" + self.config.get_value('files-path') + "/' -y '" + self.config.get_value('files-path') + "/" + file + "'")
                     else:
-                        os.system("7zr" + Initialize.get_os_extension() + " x -aoa -ofiles/ -y files/" + file)
+                        os.system("7zr" + Initialize.get_os_extension() + " x -aoa -o'" + self.config.get_value('files-path') + "/' -y '" + self.config.get_value('files-path') + "/" + file + "'")
         return True

--- a/htpclient/hashcat_cracker.py
+++ b/htpclient/hashcat_cracker.py
@@ -26,7 +26,7 @@ class HashcatCracker:
         self.executable_name = binary_download.get_version()['executable']
         k = self.executable_name.rfind(".")
         self.executable_name = self.executable_name[:k] + "." + self.executable_name[k + 1:]
-        self.cracker_path = "crackers/" + str(cracker_id) + "/"
+        self.cracker_path = self.config.get_value('crackers-path') + "/" + str(cracker_id) + "/"
         self.callPath = self.executable_name
         if Initialize.get_os() != 1:
             self.callPath = "./" + self.callPath
@@ -35,12 +35,12 @@ class HashcatCracker:
             self.executable_name = binary_download.get_version()['executable']
             k = self.executable_name.rfind(".")
             self.executable_name = self.executable_name[:k] + get_bit() + "." + self.executable_name[k + 1:]
-            self.cracker_path = "crackers/" + str(cracker_id) + "/"
+            self.cracker_path = self.config.get_value('crackers-path') + "/" + str(cracker_id) + "/"
             self.callPath = self.executable_name
             if Initialize.get_os() != 1:
                 self.callPath = "./" + self.callPath
 
-        cmd = self.callPath + " --version"
+        cmd = "'" + self.callPath + "' --version"
         output = ''
         try:
             logging.debug("CALL: " + cmd)
@@ -83,8 +83,8 @@ class HashcatCracker:
         args = " --machine-readable --quiet --status --restore-disable --session=hashtopolis"
         args += " --status-timer " + str(task['statustimer'])
         args += " --outfile-check-timer=" + str(task['statustimer'])
-        args += " --outfile-check-dir=../../hashlist_" + str(task['hashlistId'])
-        args += " -o ../../hashlists/" + str(task['hashlistId']) + ".out --outfile-format=" + self.get_outfile_format() + " -p \"" + str(chr(9)) + "\""
+        args += " --outfile-check-dir='" + self.config.get_value('zaps-path') + "/hashlist_" + str(task['hashlistId']) + "'"
+        args += " -o '" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out' --outfile-format=" + self.get_outfile_format() + " -p \"" + str(chr(9)) + "\""
         args += " -s " + str(chunk['skip'])
         args += " -l " + str(chunk['length'])
         if 'useBrain' in task and task['useBrain']:  # when using brain we set the according parameters
@@ -95,7 +95,7 @@ class HashcatCracker:
                 args += " --brain-client-features " + str(task['brainFeatures'])
         else:  # remove should only be used if we run without brain
             args += " --potfile-disable --remove --remove-timer=" + str(task['statustimer'])
-        args += " " + update_files(task['attackcmd']).replace(task['hashlistAlias'], "../../hashlists/" + str(task['hashlistId'])) + " " + task['cmdpars']
+        args += " " + update_files(task['attackcmd']).replace(task['hashlistAlias'], "'" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "' ") + task['cmdpars']
         if args.find(" -S") != -1:
             self.uses_slow_hash_flag = True
         return self.callPath + args
@@ -107,11 +107,11 @@ class HashcatCracker:
         post_args = " --machine-readable --quiet --status --remove --restore-disable --potfile-disable --session=hashtopolis"
         post_args += " --status-timer " + str(task['statustimer'])
         post_args += " --outfile-check-timer=" + str(task['statustimer'])
-        post_args += " --outfile-check-dir=../../hashlist_" + str(task['hashlistId'])
-        post_args += " -o ../../hashlists/" + str(task['hashlistId']) + ".out --outfile-format=" + self.get_outfile_format() + " -p \"" + str(chr(9)) + "\""
+        post_args += " --outfile-check-dir='" + self.config.get_value('zaps-path') + "/hashlist_" + str(task['hashlistId']) + "'"
+        post_args += " -o '" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out' --outfile-format=" + self.get_outfile_format() + " -p \"" + str(chr(9)) + "\""
         post_args += " --remove-timer=" + str(task['statustimer'])
-        post_args += " ../../hashlists/" + str(task['hashlistId'])
-        return self.callPath + pre_args + " | " + self.callPath + post_args + task['cmdpars']
+        post_args += " '" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "'"
+        return f"'{self.callPath}'" + pre_args + " | " + f"'{self.callPath}'" + post_args + task['cmdpars']
 
     # DEPRECATED
     def build_prince_command(self, task, chunk):
@@ -133,7 +133,7 @@ class HashcatCracker:
         return binary + pre_args + " | " + self.callPath + post_args + task['cmdpars']
 
     def build_preprocessor_command(self, task, chunk, preprocessor):
-        binary = "../../preprocessor/" + str(task['preprocessor']) + "/" + preprocessor['executable']
+        binary = self.config.get_value('preprocessors-path') + "/" + str(task['preprocessor']) + "/" + preprocessor['executable']
         if Initialize.get_os() != 1:
             binary = "./" + binary
         if not os.path.isfile(binary):
@@ -155,12 +155,12 @@ class HashcatCracker:
         post_args = " --machine-readable --quiet --status --remove --restore-disable --potfile-disable --session=hashtopolis"
         post_args += " --status-timer " + str(task['statustimer'])
         post_args += " --outfile-check-timer=" + str(task['statustimer'])
-        post_args += " --outfile-check-dir=../../hashlist_" + str(task['hashlistId'])
-        post_args += " -o ../../hashlists/" + str(task['hashlistId']) + ".out --outfile-format=" + self.get_outfile_format() + " -p \"" + str(chr(9)) + "\""
+        post_args += " --outfile-check-dir='" + self.config.get_value('zaps-path') + "hashlist_" + str(task['hashlistId']) + "'"
+        post_args += " -o '" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out' --outfile-format=" + self.get_outfile_format() + " -p \"" + str(chr(9)) + "\""
         post_args += " --remove-timer=" + str(task['statustimer'])
-        post_args += " ../../hashlists/" + str(task['hashlistId'])
+        post_args += " '" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "'"
         post_args += update_files(task['attackcmd']).replace(task['hashlistAlias'], '')
-        return binary + pre_args + " | " + self.callPath + post_args + task['cmdpars']
+        return f"'{binary}'" + pre_args + " | " + f"'{self.callPath}'" + post_args + task['cmdpars']
 
     def run_chunk(self, task, chunk, preprocessor):
         if 'enforcePipe' in task and task['enforcePipe']:
@@ -179,14 +179,14 @@ class HashcatCracker:
         if Initialize.get_os() == 1:
             full_cmd = full_cmd.replace("/", '\\')
         # clear old found file - earlier we deleted them, but just in case, we just move it to a unique filename if configured so
-        if os.path.exists("hashlists/" + str(task['hashlistId']) + ".out"):
+        if os.path.exists(self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out"):
             if self.config.get_value('outfile-history'):
-                os.rename("hashlists/" + str(task['hashlistId']) + ".out", "hashlists/" + str(task['hashlistId']) + "_" + str(time.time()) + ".out")
+                os.rename(self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out", self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "_" + str(time.time()) + ".out")
             else:
-                os.unlink("hashlists/" + str(task['hashlistId']) + ".out")
+                os.unlink(self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out")
         # create zap folder
-        if not os.path.exists("hashlist_" + str(task['hashlistId'])):
-            os.mkdir("hashlist_" + str(task['hashlistId']))
+        if not os.path.exists(self.config.get_value('zaps-path') + "/hashlist_" + str(task['hashlistId'])):
+            os.mkdir(self.config.get_value('zaps-path') + "/hashlist_" + str(task['hashlistId']))
         logging.debug("CALL: " + full_cmd)
         if Initialize.get_os() != 1:
             process = subprocess.Popen(full_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, cwd=self.cracker_path, preexec_fn=os.setsid)
@@ -196,7 +196,7 @@ class HashcatCracker:
         logging.debug("started cracking")
         out_thread = Thread(target=self.stream_watcher, name='stdout-watcher', args=('OUT', process.stdout))
         err_thread = Thread(target=self.stream_watcher, name='stderr-watcher', args=('ERR', process.stderr))
-        crk_thread = Thread(target=self.output_watcher, name='crack-watcher', args=("hashlists/" + str(task['hashlistId']) + ".out", process))
+        crk_thread = Thread(target=self.output_watcher, name='crack-watcher', args=(self.config.get_value('hashlists-path') + "/hashlists/" + str(task['hashlistId']) + ".out", process))
         out_thread.start()
         err_thread.start()
         crk_thread.start()
@@ -350,7 +350,7 @@ class HashcatCracker:
                                 if zaps:
                                     logging.debug("Writing zaps")
                                     zap_output = "\tFF\n".join(zaps) + '\tFF\n'
-                                    f = open("hashlist_" + str(task['hashlistId']) + "/" + str(time.time()), 'a')
+                                    f = open(self.config.get_value('zaps-path') + "/hashlist_" + str(task['hashlistId']) + "/" + str(time.time()), 'a')
                                     f.write(zap_output)
                                     f.close()
                                 logging.info("Progress:" + str("{:6.2f}".format(relative_progress / 100)) + "% Speed: " + print_speed(speed) + " Cracks: " + str(cracks_count) + " Accepted: " + str(ans['cracked']) + " Skips: " + str(ans['skipped']) + " Zaps: " + str(len(zaps)))
@@ -374,7 +374,7 @@ class HashcatCracker:
         elif 'usePreprocessor' in task.get_task() and task.get_task()['usePreprocessor']:
             return self.preprocessor_keyspace(task, chunk)
         task = task.get_task()  # TODO: refactor this to be better code
-        full_cmd = self.callPath + " --keyspace --quiet " + update_files(task['attackcmd']).replace(task['hashlistAlias'] + " ", "") + ' ' + task['cmdpars']
+        full_cmd = f"'{self.callPath}'" + " --keyspace --quiet " + update_files(task['attackcmd']).replace(task['hashlistAlias'] + " ", "") + ' ' + task['cmdpars']
         if 'useBrain' in task and task['useBrain']:
             full_cmd += " -S"
         if Initialize.get_os() == 1:
@@ -442,12 +442,12 @@ class HashcatCracker:
             split = binary.split(".")
             binary = '.'.join(split[:-1]) + get_bit() + "." + split[-1]
 
-        full_cmd = binary + " " + preprocessor['keyspaceCommand'] + " " + update_files(task.get_task()['preprocessorCommand'])
+        full_cmd = f"'{binary}'" + " " + preprocessor['keyspaceCommand'] + " " + update_files(task.get_task()['preprocessorCommand'])
         if Initialize.get_os() == 1:
             full_cmd = full_cmd.replace("/", '\\')
         try:
             logging.debug("CALL: " + full_cmd)
-            output = subprocess.check_output(full_cmd, shell=True, cwd="preprocessor/" + str(task.get_task()['preprocessor']))
+            output = subprocess.check_output(full_cmd, shell=True, cwd=self.config.get_value('preprocessors-path') + "/" + str(task.get_task()['preprocessor']))
         except subprocess.CalledProcessError:
             logging.error("Error during preprocessor keyspace measure")
             send_error("Preprocessor keyspace measure failed!", self.config.get_value('token'), task.get_task()['taskId'], None)
@@ -472,9 +472,9 @@ class HashcatCracker:
 
         args = " --machine-readable --quiet --runtime=" + str(task['bench'])
         args += " --restore-disable --potfile-disable --session=hashtopolis -p \"" + str(chr(9)) + "\" "
-        args += update_files(task['attackcmd']).replace(task['hashlistAlias'], "../../hashlists/" + str(task['hashlistId'])) + ' ' + task['cmdpars']
-        args += " -o ../../hashlists/" + str(task['hashlistId']) + ".out"
-        full_cmd = self.callPath + args
+        args += update_files(task['attackcmd']).replace(task['hashlistAlias'], "'" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "' ") + task['cmdpars']
+        args += " -o '" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out'"
+        full_cmd = f"'{self.callPath}'" + args
         if Initialize.get_os() == 1:
             full_cmd = full_cmd.replace("/", '\\')
         logging.debug("CALL: " + full_cmd)
@@ -522,16 +522,16 @@ class HashcatCracker:
         args = " --machine-readable --quiet --progress-only"
         args += " --restore-disable --potfile-disable --session=hashtopolis -p \"" + str(chr(9)) + "\" "
         if 'usePrince' in task and task['usePrince']:
-            args += get_rules_and_hl(update_files(task['attackcmd']), task['hashlistAlias']).replace(task['hashlistAlias'], "../../hashlists/" + str(task['hashlistId'])) + ' '
+            args += get_rules_and_hl(update_files(task['attackcmd']), task['hashlistAlias']).replace(task['hashlistAlias'], "'" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "' ")
             args += " example.dict" + ' ' + task['cmdpars']
         else:
-            args += update_files(task['attackcmd']).replace(task['hashlistAlias'], "../../hashlists/" + str(task['hashlistId'])) + ' ' + task['cmdpars']
+            args += update_files(task['attackcmd']).replace(task['hashlistAlias'], "'" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "' ") + task['cmdpars']
         if 'usePreprocessor' in task and task['usePreprocessor']:
             args += " example.dict"
         if 'useBrain' in task and task['useBrain']:
             args += " -S"
-        args += " -o ../../hashlists/" + str(task['hashlistId']) + ".out"
-        full_cmd = self.callPath + args
+        args += " -o '" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out'"
+        full_cmd = f"'{self.callPath}'" + args
         output = b''
         if Initialize.get_os() == 1:
             full_cmd = full_cmd.replace("/", '\\')
@@ -591,9 +591,9 @@ class HashcatCracker:
     def run_health_check(self, attack, hashlist_alias):
         args = " --machine-readable --quiet"
         args += " --restore-disable --potfile-disable --session=health "
-        args += update_files(attack).replace(hashlist_alias, "../../hashlists/health_check.txt")
-        args += " -o ../../hashlists/health_check.out"
-        full_cmd = self.callPath + args
+        args += update_files(attack).replace(hashlist_alias, "'" + self.config.get_value('hashlists-path') + "/health_check.txt'")
+        args += " -o '" + self.config.get_value('hashlists-path') + "/health_check.out'"
+        full_cmd = f"'{self.callPath}'" + args
         if Initialize.get_os() == 1:
             full_cmd = full_cmd.replace("/", '\\')
         logging.debug("CALL: " + full_cmd)

--- a/htpclient/hashcat_cracker.py
+++ b/htpclient/hashcat_cracker.py
@@ -196,7 +196,7 @@ class HashcatCracker:
         logging.debug("started cracking")
         out_thread = Thread(target=self.stream_watcher, name='stdout-watcher', args=('OUT', process.stdout))
         err_thread = Thread(target=self.stream_watcher, name='stderr-watcher', args=('ERR', process.stderr))
-        crk_thread = Thread(target=self.output_watcher, name='crack-watcher', args=(self.config.get_value('hashlists-path') + "/hashlists/" + str(task['hashlistId']) + ".out", process))
+        crk_thread = Thread(target=self.output_watcher, name='crack-watcher', args=(self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out", process))
         out_thread.start()
         err_thread.start()
         crk_thread.start()

--- a/htpclient/hashlist.py
+++ b/htpclient/hashlist.py
@@ -26,7 +26,7 @@ class Hashlist:
             sleep(5)
             return False
         else:
-            Download.download(self.config.get_value('url').replace("api/server.php", "") + ans['url'], "hashlists/" + str(hashlist_id), True)
+            Download.download(self.config.get_value('url').replace("api/server.php", "") + ans['url'], self.config.get_value('hashlists-path') + "/" + str(hashlist_id), True)
             return True
 
     def load_found(self, hashlist_id, cracker_id):
@@ -44,5 +44,5 @@ class Hashlist:
             return False
         else:
             logging.info("Saving found hashes to hashcat potfile...")
-            Download.download(self.config.get_value('url').replace("api/server.php", "") + ans['url'], "crackers/" + str(cracker_id) + "/hashcat.potfile", True)
+            Download.download(self.config.get_value('url').replace("api/server.php", "") + ans['url'], self.config.get_value('crackers-path') + "/" + str(cracker_id) + "/hashcat.potfile", True)
             return True

--- a/htpclient/helpers.py
+++ b/htpclient/helpers.py
@@ -11,6 +11,7 @@ import subprocess
 
 from htpclient.dicts import copy_and_set_token, dict_clientError
 from htpclient.jsonRequest import JsonRequest
+from htpclient.config import Config
 
 
 def log_error_and_exit(message):
@@ -70,7 +71,7 @@ def start_uftpd(os_extension, config):
         cmd += "-I " + config.get_value('multicast-device') + ' '
     else:
         cmd += "-I eth0 "  # wild guess as default
-    cmd += "-D " + os.path.abspath("files/") + ' '
+    cmd += "-D " + os.path.abspath(config.get_value('files-path') + "/") + ' '
     cmd += "-L " + os.path.abspath("multicast/" + str(time.time()) + ".log")
     logging.debug("CALL: " + cmd)
     subprocess.check_output(cmd, shell=True)
@@ -111,18 +112,17 @@ def clean_list(element_list):
 
 # the prince flag is deprecated
 def update_files(command, prince=False):
+    config = Config()
+
     split = command.split(" ")
     ret = []
     for part in split:
         # test if file exists
         if not part:
             continue
-        path = "files/" + part
+        path = config.get_value('files-path') + "/" + part
         if os.path.exists(path):
-            if prince:
-                ret.append("../" + path)
-            else:
-                ret.append("../../" + path)
+            ret.append(f"'{path}'")
         else:
             ret.append(part)
     return " %s " % " ".join(ret)

--- a/htpclient/initialize.py
+++ b/htpclient/initialize.py
@@ -206,13 +206,12 @@ class Initialize:
         else:
             logging.debug("Connection test successful!")
 
-    @staticmethod
-    def __build_directories():
-        if not os.path.isdir("crackers"):
-            os.mkdir("crackers")
-        if not os.path.isdir("files"):
-            os.mkdir("files")
-        if not os.path.isdir("hashlists"):
-            os.mkdir("hashlists")
-        if not os.path.isdir("preprocessor"):
-            os.mkdir("preprocessor")
+    def __build_directories(self):
+        if not os.path.isdir(self.config.get_value('crackers-path')):
+            os.makedirs(self.config.get_value('crackers-path'))
+        if not os.path.isdir(self.config.get_value('files-path')):
+            os.makedirs(self.config.get_value('files-path'))
+        if not os.path.isdir(self.config.get_value('hashlists-path')):
+            os.makedirs(self.config.get_value('hashlists-path'))
+        if not os.path.isdir(self.config.get_value('preprocessors-path')):
+            os.makedirs(self.config.get_value('preprocessors-path'))


### PR DESCRIPTION
Following folder locations can now be set via config:
- files/
- crackers/
- preprocessors/
- hashlists/
- zaps

Note: the deprecated prince functions were not adapted and should be removed soon-ish.