### PR TITLE
Catching version parsion exception if custom tags are used

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 ## v0.6.1 -> v0.x.x
 
+### Bugfixes
+
+* Fixed crash occurring when a custom hashcat version tag is used which contains non-numerical parts.
+
 ## v0.6.0 -> v0.6.1
 
 ### Features

--- a/htpclient/hashcat_cracker.py
+++ b/htpclient/hashcat_cracker.py
@@ -67,7 +67,7 @@ class HashcatCracker:
                 if int(str(release[0])) >= 6:
                     return "1,2,3,4"
             except ValueError:
-                pass  # if there is a custom version, we assume it's using the new format
+                return "1,2,3,4"  # if there is a custom version, we assume it's using the new format
             return "15" # if we cannot determine the version or if the release is older than 6.0.0, we will use the old format
         split = self.version_string.split('-')
         if len(split) < 2:

--- a/htpclient/hashcat_cracker.py
+++ b/htpclient/hashcat_cracker.py
@@ -63,8 +63,11 @@ class HashcatCracker:
     def get_outfile_format(self):
         if self.version_string.find('-') == -1:
             release = self.version_string.split('.')
-            if int(str(release[0])) >= 6:
-                return "1,2,3,4"
+            try:
+                if int(str(release[0])) >= 6:
+                    return "1,2,3,4"
+            except ValueError:
+                pass  # if there is a custom version, we assume it's using the new format
             return "15" # if we cannot determine the version or if the release is older than 6.0.0, we will use the old format
         split = self.version_string.split('-')
         if len(split) < 2:


### PR DESCRIPTION
In case the version tag of hashcat contains no number at the beginning (or none at all), it fails during the integer conversion where it checks which hashcat outfile format should be used.

This fix catches this exception and then assumes it is using the new format.