### PR TITLE
Temp fix for 0.7.0 path and quote issue on windows

### DIFF
--- a/htpclient/binarydownload.py
+++ b/htpclient/binarydownload.py
@@ -10,6 +10,8 @@ from htpclient.initialize import Initialize
 from htpclient.jsonRequest import JsonRequest
 from htpclient.dicts import *
 
+SEP = os.path.sep
+
 
 class BinaryDownload:
     def __init__(self, args):
@@ -98,7 +100,7 @@ class BinaryDownload:
 
     def check_prince(self):
         logging.debug("Checking if PRINCE is present...")
-        path = "prince/"
+        path = "prince" + SEP
         if os.path.isdir(path):  # if it already exists, we don't need to download it
             logging.debug("PRINCE is already downloaded")
             return True
@@ -125,8 +127,8 @@ class BinaryDownload:
             else:
                 os.system("./7zr" + Initialize.get_os_extension() + " x -otemp prince.7z")
             for name in os.listdir("temp"):  # this part needs to be done because it is compressed with the main subfolder of prince
-                if os.path.isdir("temp/" + name):
-                    os.rename("temp/" + name, "prince")
+                if os.path.isdir("temp" + SEP + name):
+                    os.rename("temp" + SEP + name, "prince")
                     break
             os.unlink("prince.7z")
             os.rmdir("temp")
@@ -135,7 +137,7 @@ class BinaryDownload:
     
     def check_preprocessor(self, task):
         logging.debug("Checking if requested preprocessor is present...")
-        path = self.config.get_value('preprocessors-path') + "/" + str(task.get_task()['preprocessor']) + "/"
+        path = self.config.get_value('preprocessors-path') + SEP + str(task.get_task()['preprocessor']) + SEP
         query = copy_and_set_token(dict_downloadBinary, self.config.get_value('token'))
         query['type'] = 'preprocessor'
         query['preprocessorId'] = task.get_task()['preprocessor']
@@ -164,8 +166,8 @@ class BinaryDownload:
             else:
                 os.system("./7zr" + Initialize.get_os_extension() + " x -otemp temp.7z")
             for name in os.listdir("temp"):  # this part needs to be done because it is compressed with the main subfolder of prince
-                if os.path.isdir("temp/" + name):
-                    os.rename("temp/" + name, path)
+                if os.path.isdir("temp" + SEP + name):
+                    os.rename("temp" + SEP + name, path)
                     break
             os.unlink("temp.7z")
             os.rmdir("temp")
@@ -173,7 +175,7 @@ class BinaryDownload:
         return True
 
     def check_version(self, cracker_id):
-        path = self.config.get_value('crackers-path') + "/" + str(cracker_id) + "/"
+        path = self.config.get_value('crackers-path') + SEP + str(cracker_id) + SEP
         query = copy_and_set_token(dict_downloadBinary, self.config.get_value('token'))
         query['type'] = 'cracker'
         query['binaryVersionId'] = cracker_id
@@ -191,19 +193,19 @@ class BinaryDownload:
             self.last_version = ans
             if not os.path.isdir(path):
                 # we need to download the 7zip
-                if not Download.download(ans['url'], self.config.get_value('crackers-path') + "/" + str(cracker_id) + ".7z"):
+                if not Download.download(ans['url'], self.config.get_value('crackers-path') + SEP + str(cracker_id) + ".7z"):
                     logging.error("Download of cracker binary failed!")
                     sleep(5)
                     return False
                 if Initialize.get_os() == 1:
-                    os.system("7zr" + Initialize.get_os_extension() + " x -o'" + self.config.get_value('crackers-path') + "/temp' '" + self.config.get_value('crackers-path') + "/" + str(cracker_id) + ".7z'")
+                    os.system("7zr" + Initialize.get_os_extension() + ' x -o"' + self.config.get_value('crackers-path') + SEP + 'temp" "' + self.config.get_value('crackers-path') + SEP + str(cracker_id) + '.7z"')
                 else:
-                    os.system("./7zr" + Initialize.get_os_extension() + " x -o'" + self.config.get_value('crackers-path') + "/temp' '" + self.config.get_value('crackers-path') + "/" + str(cracker_id) + ".7z'")
-                os.unlink(self.config.get_value('crackers-path') + "/" + str(cracker_id) + ".7z")
-                for name in os.listdir(self.config.get_value('crackers-path') + "/temp"):
-                    if os.path.isdir(self.config.get_value('crackers-path') + "/temp/" + name):
-                        os.rename(self.config.get_value('crackers-path') + "/temp/" + name, self.config.get_value('crackers-path') + "/" + str(cracker_id))
+                    os.system("./7zr" + Initialize.get_os_extension() + ' x -o"' + self.config.get_value('crackers-path') + SEP + 'temp" "' + self.config.get_value('crackers-path') + SEP + str(cracker_id) + '.7z"')
+                os.unlink(self.config.get_value('crackers-path') + SEP + str(cracker_id) + ".7z")
+                for name in os.listdir(self.config.get_value('crackers-path') + SEP + "temp"):
+                    if os.path.isdir(self.config.get_value('crackers-path') + SEP + "temp" + SEP + name):
+                        os.rename(self.config.get_value('crackers-path') + SEP + "temp" + SEP + name, self.config.get_value('crackers-path') + SEP + str(cracker_id))
                     else:
-                        os.rename(self.config.get_value('crackers-path') + "/temp", self.config.get_value('crackers-path') + "/" + str(cracker_id))
+                        os.rename(self.config.get_value('crackers-path') + SEP + "temp", self.config.get_value('crackers-path') + SEP + str(cracker_id))
                         break
         return True

--- a/htpclient/hashcat_cracker.py
+++ b/htpclient/hashcat_cracker.py
@@ -15,6 +15,8 @@ from htpclient.jsonRequest import JsonRequest, os
 from htpclient.helpers import send_error, update_files, kill_hashcat, get_bit, print_speed, get_rules_and_hl, get_wordlist, escape_ansi
 from htpclient.dicts import *
 
+SEP = os.path.sep
+
 
 class HashcatCracker:
     def __init__(self, cracker_id, binary_download):
@@ -26,7 +28,7 @@ class HashcatCracker:
         self.executable_name = binary_download.get_version()['executable']
         k = self.executable_name.rfind(".")
         self.executable_name = self.executable_name[:k] + "." + self.executable_name[k + 1:]
-        self.cracker_path = self.config.get_value('crackers-path') + "/" + str(cracker_id) + "/"
+        self.cracker_path = self.config.get_value('crackers-path') + SEP + str(cracker_id) + SEP
         self.callPath = self.executable_name
         if Initialize.get_os() != 1:
             self.callPath = "./" + self.callPath
@@ -35,12 +37,12 @@ class HashcatCracker:
             self.executable_name = binary_download.get_version()['executable']
             k = self.executable_name.rfind(".")
             self.executable_name = self.executable_name[:k] + get_bit() + "." + self.executable_name[k + 1:]
-            self.cracker_path = self.config.get_value('crackers-path') + "/" + str(cracker_id) + "/"
+            self.cracker_path = self.config.get_value('crackers-path') + SEP + str(cracker_id) + SEP
             self.callPath = self.executable_name
             if Initialize.get_os() != 1:
                 self.callPath = "./" + self.callPath
 
-        cmd = "'" + self.callPath + "' --version"
+        cmd = '"' + self.callPath + '" --version'
         output = ''
         try:
             logging.debug("CALL: " + cmd)
@@ -86,8 +88,8 @@ class HashcatCracker:
         args = " --machine-readable --quiet --status --restore-disable --session=hashtopolis"
         args += " --status-timer " + str(task['statustimer'])
         args += " --outfile-check-timer=" + str(task['statustimer'])
-        args += " --outfile-check-dir='" + self.config.get_value('zaps-path') + "/hashlist_" + str(task['hashlistId']) + "'"
-        args += " -o '" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out' --outfile-format=" + self.get_outfile_format() + " -p \"" + str(chr(9)) + "\""
+        args += ' --outfile-check-dir="' + self.config.get_value('zaps-path') + SEP + "hashlist_" + str(task['hashlistId']) + '"'
+        args += ' -o "' + self.config.get_value('hashlists-path') + SEP + str(task['hashlistId']) + '.out" --outfile-format=' + self.get_outfile_format() + ' -p "0x09"'
         args += " -s " + str(chunk['skip'])
         args += " -l " + str(chunk['length'])
         if 'useBrain' in task and task['useBrain']:  # when using brain we set the according parameters
@@ -98,7 +100,7 @@ class HashcatCracker:
                 args += " --brain-client-features " + str(task['brainFeatures'])
         else:  # remove should only be used if we run without brain
             args += " --potfile-disable --remove --remove-timer=" + str(task['statustimer'])
-        args += " " + update_files(task['attackcmd']).replace(task['hashlistAlias'], "'" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "' ") + task['cmdpars']
+        args += " " + update_files(task['attackcmd']).replace(task['hashlistAlias'], '"' + self.config.get_value('hashlists-path') + SEP + str(task['hashlistId']) + '" ') + task['cmdpars']
         if args.find(" -S") != -1:
             self.uses_slow_hash_flag = True
         return self.callPath + args
@@ -524,18 +526,18 @@ class HashcatCracker:
 
     def run_speed_benchmark(self, task):
         args = " --machine-readable --quiet --progress-only"
-        args += " --restore-disable --potfile-disable --session=hashtopolis -p \"" + str(chr(9)) + "\" "
+        args += " --restore-disable --potfile-disable --session=hashtopolis -p \"0x09\" "
         if 'usePrince' in task and task['usePrince']:
             args += get_rules_and_hl(update_files(task['attackcmd']), task['hashlistAlias']).replace(task['hashlistAlias'], "'" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "' ")
             args += " example.dict" + ' ' + task['cmdpars']
         else:
-            args += update_files(task['attackcmd']).replace(task['hashlistAlias'], "'" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + "' ") + task['cmdpars']
+            args += update_files(task['attackcmd']).replace(task['hashlistAlias'], '"' + self.config.get_value('hashlists-path') + SEP + str(task['hashlistId']) + '" ') + task['cmdpars']
         if 'usePreprocessor' in task and task['usePreprocessor']:
             args += " example.dict"
         if 'useBrain' in task and task['useBrain']:
             args += " -S"
-        args += " -o '" + self.config.get_value('hashlists-path') + "/" + str(task['hashlistId']) + ".out'"
-        full_cmd = f"'{self.callPath}'" + args
+        args += ' -o "' + self.config.get_value('hashlists-path') + SEP + str(task['hashlistId']) + '.out"'
+        full_cmd = f'"{self.callPath}"' + args
         output = b''
         if Initialize.get_os() == 1:
             full_cmd = full_cmd.replace("/", '\\')
@@ -595,8 +597,8 @@ class HashcatCracker:
     def run_health_check(self, attack, hashlist_alias):
         args = " --machine-readable --quiet"
         args += " --restore-disable --potfile-disable --session=health "
-        args += update_files(attack).replace(hashlist_alias, "'" + self.config.get_value('hashlists-path') + "/health_check.txt'")
-        args += " -o '" + self.config.get_value('hashlists-path') + "/health_check.out'"
+        args += update_files(attack).replace(hashlist_alias, "'" + self.config.get_value('hashlists-path') + SEP + "health_check.txt'")
+        args += " -o '" + self.config.get_value('hashlists-path') + SEP + "health_check.out'"
         full_cmd = f"'{self.callPath}'" + args
         if Initialize.get_os() == 1:
             full_cmd = full_cmd.replace("/", '\\')

--- a/htpclient/helpers.py
+++ b/htpclient/helpers.py
@@ -13,6 +13,8 @@ from htpclient.dicts import copy_and_set_token, dict_clientError
 from htpclient.jsonRequest import JsonRequest
 from htpclient.config import Config
 
+SEP = os.path.sep
+
 
 def log_error_and_exit(message):
     logging.error(message)
@@ -120,7 +122,7 @@ def update_files(command, prince=False):
         # test if file exists
         if not part:
             continue
-        path = config.get_value('files-path') + "/" + part
+        path = config.get_value('files-path') + SEP + part
         if os.path.exists(path):
             ret.append(f"'{path}'")
         else:


### PR DESCRIPTION
As per the request from @zyronix on the discord I've made it a PR.

However it's quite an ugly fix and has not been well tested. I only fixed just enough to get the client to run on windows for a standard bruteforce attack with nothing else such as other files or pre processing. So there are probably other paths that have yet to be fixed.

It creates a global SEP variable that holds the OS specific path separator and uses that in place of hard coded forward slashes.
And it uses double quotes in place of single quotes in the argument building as cmd doesn't support single.
It also switches the hashcat separator char argument to the literal characters `0x09` as hashcat supports that natively now. Windows cmd was choking on the tab char.

In time I may attempt a proper fix with pathlib and switching to building an argument list instead of an argument string containing hardcoded quotes but for now this at least has it running on windows.