### PR TITLE
Adding user cmd and post command, changing certificate ca for nodejs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,7 @@ ARG DEV_CONTAINER_USER_CMD_POST
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
+ENV NODE_OPTIONS='--use-openssl-ca'
 
 # Check for and run optional user-supplied command to enable (advanced) customizations of the dev container
 RUN if [ -n "${DEV_CONTAINER_USER_CMD_PRE}" ]; then echo "${DEV_CONTAINER_USER_CMD_PRE}" | sh ; fi

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,13 @@
 FROM ubuntu:20.04
 
-ARG DEV_CONTAINER_USER_CMD
+ARG DEV_CONTAINER_USER_CMD_PRE
+ARG DEV_CONTAINER_USER_CMD_POST
 
 # Avoid warnings by switching to noninteractive
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Check for and run optional user-supplied command to enable (advanced) customizations of the dev container
-RUN if [ -n "${DEV_CONTAINER_USER_CMD}" ]; then echo "${DEV_CONTAINER_USER_CMD}" | sh ; fi
+RUN if [ -n "${DEV_CONTAINER_USER_CMD_PRE}" ]; then echo "${DEV_CONTAINER_USER_CMD_PRE}" | sh ; fi
 
 RUN groupadd vscode && useradd -rm -d /app -s /bin/bash -g vscode -u 1001 vscode
 
@@ -42,6 +43,9 @@ WORKDIR /app
 USER vscode
 COPY requirements.txt /app/src/
 RUN /usr/bin/pip3 install -r src/requirements.txt
+
+# Check for and run optional user-supplied command to enable (advanced) customizations of the dev container
+RUN if [ -n "${DEV_CONTAINER_USER_CMD_POST}" ]; then echo "${DEV_CONTAINER_USER_CMD_POST}" | sh ; fi
 
 # Preventing container from exiting
 CMD tail -f /dev/null

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,9 @@
 	"service": "hashtopolis-agent",
 
 	"workspaceFolder": "/app/src",
-
+	"remoteEnv": {
+		"NODE_OPTIONS": "--use-openssl-ca",
+	},
 	"extensions": [
 		"ms-python.python"
 	],

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -6,7 +6,8 @@ services:
       context: ..
       dockerfile: .devcontainer/Dockerfile
       args:
-        - DEV_CONTAINER_USER_CMD
+        - DEV_CONTAINER_USER_CMD_PRE
+        - DEV_CONTAINER_USER_CMD_POST
     volumes:
       # This is where VS Code should expect to find your project's source code
       # and the value of "workspaceFolder" in .devcontainer/devcontainer.json


### PR DESCRIPTION
Changing parameter

DEV_CONTAINER_USER_CMD

To two new parameters:

DEV_CONTAINER_USER_CMD_PRE
DEV_CONTAINER_USER_CMD_POST

This allows for customization and the start and at the end of the dev container.

Also added changes for the certificate store of nodejs. See: https://github.com/hashtopolis/server/pull/849