### PR TITLE
Fixed network not existing when starting devcontainer agent

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.5"
 services:
   hashtopolis-agent:
     container_name: hashtopolis_agent
@@ -12,8 +12,10 @@ services:
       # This is where VS Code should expect to find your project's source code
       # and the value of "workspaceFolder" in .devcontainer/devcontainer.json
       - ..:/app/src
+    networks:
+      - hashtopolis_dev
 
 networks:
-  default:
-      external:
-        name: hashtopolis_dev
+  hashtopolis_dev:
+    # This network will also be used by the hashtopolis server and db
+    name: hashtopolis_dev


### PR DESCRIPTION
When you start the dev-container of the agent before the server it would return an error. Since docker compose 3.5 you can use a named network. This pull requests fixes that issue.