### PR TITLE
Remove increment options from benchmark execution.

### DIFF
--- a/htpclient/hashcat_cracker.py
+++ b/htpclient/hashcat_cracker.py
@@ -5,8 +5,8 @@ import psutil
 from pathlib import Path
 from time import sleep
 from queue import Queue, Empty
+import re
 from threading import Thread, Lock
-
 import time
 
 from htpclient.config import Config
@@ -651,6 +651,9 @@ class HashcatCracker:
 
             # Replace #HL# with the real hashlist
             attackcmd = attackcmd.replace(task['hashlistAlias'], f'"{hashlist_path}"')
+            attackcmd = re.sub(r'--increment(\s+|$)', '', attackcmd)
+            attackcmd = re.sub(r'--increment-(max|min)(=\S+|\s+\S+)?\s*', '', attackcmd)
+            attackcmd = attackcmd.replace('--', f'"{hashlist_path}"')
 
             args.append(attackcmd)
             args.append(task['cmdpars'])


### PR DESCRIPTION
I was running an incrementing hash and the benchmark was failing because of a passed in increment option. I'm not sure if this is complete as I'm new to hashcat, but this PR fixed it for me. Please let me know if you'd like edits.