### PR TITLE
First dockerization possibilities for agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine/git AS preprocess
+
+RUN apk add --no-cache bash zip
+
+COPY . /htp
+
+RUN cd /htp && bash build.sh && ls /htp
+
+FROM nvidia/cuda:12.3.2-devel-ubuntu22.04 AS agent-cuda
+
+ENV APPDIR=/htp-agent
+
+WORKDIR ${APPDIR}
+
+RUN \
+  --mount=type=cache,target=/var/cache/apt \
+  apt-get update && apt-get install -y --no-install-recommends \
+  zip \
+  p7zip-full \
+  git \
+  python3 \
+  python3-pip \
+  python3-psutil \
+  python3-requests \
+  pciutils \
+  ca-certificates \
+  rsync \
+  ocl-icd-libopencl1 \
+  clinfo \
+  curl && \
+  rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/OpenCL/vendors && \
+    echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd && \
+    echo "/usr/local/nvidia/lib" >> /etc/ld.so.conf.d/nvidia.conf && \
+    echo "/usr/local/nvidia/lib64" >> /etc/ld.so.conf.d/nvidia.conf
+
+ENV PATH=/usr/local/nvidia/bin:${PATH}
+ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+
+COPY --from=preprocess /htp/hashtopolis.zip ${APPDIR}/
+
+
+RUN pip3 install -r requirements.txt
+
+ENTRYPOINT ["python3", "hashtopolis.zip"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN cd /htp && bash build.sh && ls /htp
 
 FROM nvidia/cuda:12.3.2-devel-ubuntu22.04 AS agent-cuda
 
-ENV APPDIR=/htp-agent
+ENV APPDIR=/htp
 
 WORKDIR ${APPDIR}
 
@@ -40,6 +40,7 @@ ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_P
 
 COPY --from=preprocess /htp/hashtopolis.zip ${APPDIR}/
 
+COPY requirements.txt ${APPDIR}
 
 RUN pip3 install -r requirements.txt
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,0 +1,5 @@
+{
+  "debug": true,
+  "voucher": "<voucher>",
+  "url": "http://<server-ip>:<server-port>/api/server.php"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   hashtopolis-agent:
     container_name: hashtopolis-agent
-    image: htp-agent #hashtopolis/agent:latest
+    image: hashtopolis/agent:latest
     volumes:
       - ./config.json:/htp/config.json
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+services:
+  hashtopolis-agent:
+    container_name: hashtopolis-agent
+    image: htp-agent #hashtopolis/agent:latest
+    volumes:
+      - ./config.json:/htp/config.json
+    deploy:
+      resources:
+        reservations:
+          devices:
+          - driver: nvidia
+            count: all
+            capabilities: [gpu]


### PR DESCRIPTION
The documentation for hashtopolis needs to be updated after this is merged and available with the following things:

- explain how you an persistent agent can be deployed with docker compose
- explain how a agent can be deployed which is only alive until it stops (e.g. cloud)
- explain/link how to set up docker so that it can provide the gpu inside the docker container